### PR TITLE
Filter out AccountData that fails to construct

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
+            - v2-dependencies-{{ checksum "requirements.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v2-dependencies-
 
       - run:
           name: install dependencies
@@ -37,7 +37,7 @@ jobs:
       - save_cache:
           paths:
             - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+          key: v2-dependencies-{{ checksum "requirements.txt" }}
       
       - run:
           name: typecheck

--- a/bankroll/broker/aggregator.py
+++ b/bankroll/broker/aggregator.py
@@ -26,10 +26,13 @@ class AccountAggregator(AccountData):
         cls, settings: Mapping[Settings, str], lenient: bool
     ) -> "AccountAggregator":
         return AccountAggregator(
-            accounts=(
-                accountCls.fromSettings(settings, lenient=lenient)
-                for accountCls in AccountData.__subclasses__()
-                if not issubclass(accountCls, AccountAggregator)
+            accounts=filter(
+                None,
+                (
+                    accountCls.fromSettings(settings, lenient=lenient)
+                    for accountCls in AccountData.__subclasses__()
+                    if not issubclass(accountCls, AccountAggregator)
+                ),
             ),
             lenient=lenient,
         )


### PR DESCRIPTION
I can't remember why I removed this, but it is necessary in the end. For example, `ibkr` can fail to construct if an active connection is missing.